### PR TITLE
update ScientificTypes to ScientificTypesBase

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,18 +1,32 @@
-name = "StatisticalTraits"
-uuid = "64bff920-2084-43da-a3e6-9bb72801c0c9"
+name = "ScientificTypes"
+uuid = "2e2323e0-db8b-457b-ae0d-bdfb3bc63afd"
 authors = ["Anthony D. Blaom <anthony.blaom@gmail.com>"]
-version = "1.1.0"
+version = "0.4.8"
 
 [deps]
-ScientificTypes = "321657f4-b219-11e9-178b-2701a2544e81"
+CategoricalArrays = "324d7699-5711-5eae-9e2f-1d82baa6b597"
+ColorTypes = "3da002f7-5984-5a60-b8a6-cbb66c0b333f"
+Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
+PersistenceDiagramsBase = "b1ad91c1-539c-4ace-90bd-ea06abc420fa"
+PrettyTables = "08abe8d2-0d0c-5749-adfa-8a2ac140af0d"
+ScientificTypesBase = "30f210dd-8aff-4c5f-94ba-8e64358c1161"
+StatisticalTraits = "64bff920-2084-43da-a3e6-9bb72801c0c9"
+Tables = "bd369af6-aec1-5ad0-b16a-f7cc5008161c"
 
 [compat]
-ScientificTypes = "^1"
-julia = "^1"
+CategoricalArrays = "0.8, 0.9, 0.10"
+ColorTypes = "0.9, 0.10, 0.11"
+PersistenceDiagramsBase = "0.1"
+PrettyTables = "1"
+StatisticalTraits = "0.1, 1.0"
+Tables = "1"
+julia = "1"
 
 [extras]
-SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
+CSV = "336ed68f-0bac-5ca0-87d4-7b16caf5d00b"
+DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
+Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Test", "SparseArrays"]
+test = ["Test", "CSV", "DataFrames", "Random"]

--- a/Project.toml
+++ b/Project.toml
@@ -1,32 +1,18 @@
-name = "ScientificTypes"
-uuid = "2e2323e0-db8b-457b-ae0d-bdfb3bc63afd"
+name = "StatisticalTraits"
+uuid = "64bff920-2084-43da-a3e6-9bb72801c0c9"
 authors = ["Anthony D. Blaom <anthony.blaom@gmail.com>"]
-version = "0.4.8"
+version = "1.1.1"
 
 [deps]
-CategoricalArrays = "324d7699-5711-5eae-9e2f-1d82baa6b597"
-ColorTypes = "3da002f7-5984-5a60-b8a6-cbb66c0b333f"
-Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
-PersistenceDiagramsBase = "b1ad91c1-539c-4ace-90bd-ea06abc420fa"
-PrettyTables = "08abe8d2-0d0c-5749-adfa-8a2ac140af0d"
 ScientificTypesBase = "30f210dd-8aff-4c5f-94ba-8e64358c1161"
-StatisticalTraits = "64bff920-2084-43da-a3e6-9bb72801c0c9"
-Tables = "bd369af6-aec1-5ad0-b16a-f7cc5008161c"
 
 [compat]
-CategoricalArrays = "0.8, 0.9, 0.10"
-ColorTypes = "0.9, 0.10, 0.11"
-PersistenceDiagramsBase = "0.1"
-PrettyTables = "1"
-StatisticalTraits = "0.1, 1.0"
-Tables = "1"
-julia = "1"
+ScientificTypesBase = "^1"
+julia = "^1"
 
 [extras]
-CSV = "336ed68f-0bac-5ca0-87d4-7b16caf5d00b"
-DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
-Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Test", "CSV", "DataFrames", "Random"]
+test = ["Test", "SparseArrays"]

--- a/src/StatisticalTraits.jl
+++ b/src/StatisticalTraits.jl
@@ -1,6 +1,6 @@
 module StatisticalTraits
 
-using ScientificTypes
+using ScientificTypesBase
 import Base.instances
 
 ## CONSTANTS
@@ -125,7 +125,7 @@ snakecase(s::Symbol) = Symbol(snakecase(string(s)))
 ## TRAITS
 
 # The following can return any scientific type, that is, any type
-# defined in the package ScientificTypes.jl, and any ordinary type
+# defined in the package ScientificTypesBase.jl, and any ordinary type
 # that functions as a scientific type (eg, `Missing`). Here "target"
 # is a synonym for "labels", as in supervised learning; "input" is a
 # synonym for "features":
@@ -207,11 +207,11 @@ traits that are meaninful for the object.
 *Note on overloading.* This method can be overloaded directly, as in
 `info(X::SomeAbstractType) = ...` or, using `info(X,
 ::Val{:some_trait}) = ...` where `:some_trait` is a key of
-`ScientificTypes.TRAIT_FUNCTION_GIVEN_NAME` (such as `:is_measure`
+`ScientificTypesBase.TRAIT_FUNCTION_GIVEN_NAME` (such as `:is_measure`
 with value `is_measure`).
 
 """
-info(X) = info(X, Val(ScientificTypes.trait(X)))
+info(X) = info(X, Val(ScientificTypesBase.trait(X)))
 info(X, ::Val{:other}) = NamedTuple()
 
 end # module

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,6 @@
 using Test
 using StatisticalTraits
-using ScientificTypes
+using ScientificTypesBase
 import SparseArrays
 
 module Fruit


### PR DESCRIPTION
In line with the migration of https://github.com/alan-turing-institute/ScientficTypes.jl` to https://github.com/JuliaAI/ScientificTypesBase.jl and https://github.com/JuliaAI/MLJScientificTypes.jl to https://github.com/JuliaAI/ScientificTypes.jl, this PR should be merged before https://github.com/JuliaAI/ScientificTypes.jl/pull/126 gets merged. 
cc. @ablaom  cc. @juliohm